### PR TITLE
Put quotes around the cache URL

### DIFF
--- a/smos-docs-site/content/pages/installation/nixos.markdown
+++ b/smos-docs-site/content/pages/installation/nixos.markdown
@@ -35,7 +35,7 @@ If you use cachix, you can configure the `smos.cachix.org` cache as a public cac
 
 ``` nix
 nix.binaryCaches = [
-  https://smos.cachix.org
+  "https://smos.cachix.org"
 ];
 nix.binaryCachePublicKeys = [
   "smos.cachix.org-1:YOs/tLEliRoyhx7PnNw36cw2Zvbw5R0ASZaUlpUv+yM="


### PR DESCRIPTION
Unquoted URLs are deprecated https://github.com/NixOS/rfcs/pull/45